### PR TITLE
add bar width and leading offset configuration options

### DIFF
--- a/bar.c
+++ b/bar.c
@@ -322,8 +322,11 @@ init (void)
 
     /* Grab infos from the first screen */
     scr  = xcb_setup_roots_iterator (xcb_get_setup (c)).data;
-    bar_width   = scr->width_in_pixels;
     root = scr->root;
+
+    /* where to place the window */
+    y = (bar_bottom) ? (scr->height_in_pixels - BAR_HEIGHT) : 0;
+    bar_width = (BAR_WIDTH < 0) ? (scr->width_in_pixels - OFFSET) : BAR_WIDTH;
 
     /* Load the font */
     if (font_load ((const char* []){ BAR_FONT }))
@@ -331,12 +334,8 @@ init (void)
 
     /* Create the main window */
     win = xcb_generate_id (c);
-    if (bar_bottom)
-        y = scr->height_in_pixels - BAR_HEIGHT;
-    else
-        y = 0;
-    xcb_create_window (c, XCB_COPY_FROM_PARENT, win, root, 0, y,
-            bar_width, BAR_HEIGHT, 0, XCB_WINDOW_CLASS_INPUT_OUTPUT, scr->root_visual, 
+    xcb_create_window (c, XCB_COPY_FROM_PARENT, win, root, OFFSET, y, bar_width,
+            BAR_HEIGHT, 0, XCB_WINDOW_CLASS_INPUT_OUTPUT, scr->root_visual,
             XCB_CW_BACK_PIXEL | XCB_CW_EVENT_MASK, (const uint32_t []){ palette[0], XCB_EVENT_MASK_EXPOSURE });
 
     /* Set EWMH hints */

--- a/config.def.h
+++ b/config.def.h
@@ -1,5 +1,9 @@
 /* The height of the bar (in pixels) */
 #define BAR_HEIGHT  18
+/* The width of the bar. Set to -1 to fit screen */
+#define BAR_WIDTH   -1
+/* Offset from the left. Set to 0 to have no effect */
+#define OFFSET 0
 /* Choose between an underline or an overline */
 #define BAR_UNDERLINE 1
 /* The thickness of the underline (in pixels). Set to 0 to disable. */


### PR DESCRIPTION
Adds `BAR_WIDTH` and `OFFSET` configuration options.

`OFFSET` defines where the window of the bar should be on the _x_ axis.
If set to 0, the the bar is placed where it is placed now ( `(0, 0)` )

`BAR_WIDTH` sets the width of the bar. 
If set to 0 then the whole screen width is used, minus the offset.
This is done, so that the bar fits the screen, if offset was set.
If the offset is too big, then the width is reset to the screen width.
If offset is also 0, then the whole screen width is used.

I am not sure whether `OFFSET` would be better named `BAR_OFFSET`.. 

---
#### rationale

Lately I use two monitors with monsterwm's xinerama-init branch.
The one is small, and I'd prefer to hide the statusbar, but hiding it
also hides the desktop information, because bar expands to the 
whole screen width.
I use this to show the bar only on the large monitor, by setting an 
offset of 1280 (the small monitor's resolution/width). Width stays 0, 
so that the bar expands to the whole width of the large monitor. 

So, I dont really use width but thought it might be useful to others,
ie setting an offset and width to get the bar to cover only rigth half 
of the screen, so one can use it above dwm's statusbar .. etc

Anyway, If you think this is useful, pull :zap:
