### PR TITLE
Added Uninstall into Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ install: bar
 	install -m755 bar ${DESTDIR}${BINDIR}/bar
 
 uninstall:
-	@echo removing executable file from ${DESTDIR}${BINDIR}
 	rm -f ${DESTDIR}${BINDIR}/bar
 
 .PHONY: all debug clean install


### PR DESCRIPTION
I just added the option uninstall. Now, you don't need to do <code>rm -f /usr/bin/bar</code> yourself.
It's cleaner.
