### PR TITLE
Operators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ EXEC = bar
 SRCS = bar.c
 OBJS = ${SRCS:.c=.o}
 
-PREFIX?=/usr/local
+PREFIX?=/usr
 BINDIR=${PREFIX}/bin
 
 all: ${EXEC}


### PR DESCRIPTION
With a custom PKGBUILD (on Archlinux), Makepkg command fails with the previous operators. Now, we can build the package without any issues.
