### PR TITLE
Add (basic) optional Xinerama support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@ CC	?= gcc
 STRIP ?= strip
 CFLAGS = -std=c99 -fshort-wchar -Os
 LDFLAGS = -lxcb
+XINERAMA ?= 0
+ifneq "$(XINERAMA)" "0"
+	LDFLAGS += -lxcb-xinerama
+	CFLAGS  += -DXINERAMA=${XINERAMA}
+endif
 CFDEBUG = -g3 -pedantic -Wall -Wunused-parameter -Wlong-long\
 		  -Wsign-conversion -Wconversion -Wimplicit-function-declaration
 


### PR DESCRIPTION
This commit adds optional Xinerama support (it's loosely based on https://github.com/llchan/bar/commit/9bfec1d118e9d302e1f14ac4978606fdf9aa8e7e#commitcomment-2249694)

A few of things to note:
1. The call to get the first X screen's geometry is now mostly redundant (with Xinerama support enabled) as the geometry can be calculated by summing the monitor widths.
2. This patch does not handle adding and removing monitors.
3. This patch does not deal with offset monitors.

`\s[0-9]` will restrict text the specified screen, `\sn` will advance to the next screen, `\sp` will go back to the previous screen, and  `\sr` will restrict text to the right (last) screen, and `\sl` will restrict text to the left (first) screen.
