### PR TITLE
Don't free the screen resources reply until we absolutely have to.

### DIFF
--- a/bar.c
+++ b/bar.c
@@ -414,7 +414,6 @@ get_randr_outputs(void)
     num = xcb_randr_get_screen_resources_current_outputs_length(rres_reply);
     outputs = xcb_randr_get_screen_resources_current_outputs(rres_reply);
     config_timestamp = rres_reply->config_timestamp;
-    free(rres_reply);
     if (num < 1) {
         fprintf(stderr, "Failed to get current randr outputs\n");
         return;
@@ -497,6 +496,7 @@ get_randr_outputs(void)
             j++;
         }
     }
+    free(rres_reply);
 }
 
 void


### PR DESCRIPTION
On my system, premature free'ing resulted in an error at the xcb_randr_get_output_info_reply call, so randr didn't work at all.

I can provide a bit more info about this, if necessary - the fix does seem very strange, but I assure it has fixed things for me. It was very difficult to debug, and I still don't really understand how it happened - I imagine the config_timestamp and rres_reply structs are sharing some internal info, or something like that.
