### PR TITLE
Fix the bounds checking for area_get.

### DIFF
--- a/bar.c
+++ b/bar.c
@@ -212,7 +212,7 @@ area_t *
 area_get (xcb_window_t win, const int x)
 {
     for (int i = 0; i < astack.pos; i++)
-        if (astack.slot[i].window == win && x > astack.slot[i].begin && x < astack.slot[i].end)
+        if (astack.slot[i].window == win && x >= astack.slot[i].begin && x < astack.slot[i].end)
             return &astack.slot[i];
     return NULL;
 }


### PR DESCRIPTION
Fixes mouse at far left (x=0) not being able to click an area that starts at 0. Also fixes unclickable pixel between two adjacent areas

example
panel string

```
%{l}%{A:desktop 1:} 1 %{A}%{A:desktop 2:} 2 %{A}%{A:desktop 3:} 3 %{A}
```

panel output

```
 1  2  3 
```

example coordinates for area.begin-area.end would be
0-18 18-36 36-54

If you click at x=18 then neither 1 nor 2 would be clicked with old logic.
