### PR TITLE
Add break from main loop when X conn has error

### DIFF
--- a/bar.c
+++ b/bar.c
@@ -1119,6 +1119,10 @@ main (int argc, char **argv)
     for (;;) {
         bool redraw = false;
 
+        /* If connection is in error state, then it has been shut down. */
+        if (xcb_connection_has_error(c))
+            break;
+
         if (poll(pollin, 2, -1) > 0) {
             if (pollin[0].revents & POLLHUP) {      /* No more data... */
                 if (permanent) pollin[0].fd = -1;   /* ...null the fd and continue polling :D */


### PR DESCRIPTION
Errors covered by xcb_connection_has_error() are said to be unrecoverable, so the connection has been closed if it returns true. I have looked at the source for xcb_connection_has _error and the overall cost of this check is negligible. This should ensure bar shuts down when the connection is closed and take care of https://github.com/LemonBoy/bar/issues/94.