### PR TITLE
Font selection

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -84,6 +84,10 @@ Set the text background color. The parameter I<color> can be I<-> or a color in 
 
 Set the text foreground color. The parameter I<color> can be I<-> or a color in one of the formats mentioned before. The special value I<-> resets the color to the default one.
 
+=item B<T>I<index>
+
+Set the font used to draw the following text. The parameter I<index> is a 1-based index of the font list supplied to bar. Any other value (for example I<->) resets bar to normal behaviour (matching the first font that can be used for that character). If the selected font can't be used to draw a character, bar will fall back to normal behaviour for that character.
+
 =item B<U>I<color>
 
 Set the text underline color. The parameter I<color> can be I<-> or a color in one of the formats mentioned before. The special value I<-> resets the color to the default one.
@@ -164,6 +168,6 @@ L<git repository|https://github.com/LemonBoy/bar>
 
 Xinerama support was kindly contributed by Stebalien
 
-RandR support was kindly contributed by jvvv 
+RandR support was kindly contributed by jvvv
 
 Clickable areas support was heavily based off u-ra contribution


### PR DESCRIPTION
This PR adds the ability to change the font used to draw the following characters. The fonts can be selected with %{Ti}, where index is a zero-based index of the font list supplied to bar. Bar can be reset to the default fallback behaviour by giving any non-index, for example %{T-}. It will also fall back if the current character can't be drawn with the selected font.