### PR TITLE
Add support for named randr outputs.

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -24,6 +24,10 @@ Display the help and exit.
 
 Set the window geometry. If a parameter is omitted it's filled with the default value. If the I<y> parameter is specified along with the B<-b> switch then the position is relative to the bottom of the screen.
 
+=item B<-o> I<name>
+
+Set next output to I<name>. May be used multiple times; order is significant. If any B<-o> options are given, only B<-o> specified monitors will be used. Invalid output names are silently ignored. (only supported on randr configurations at this time)
+
 =item B<-b>
 
 Dock the bar at the bottom of the screen.
@@ -122,6 +126,11 @@ First/last monitor.
 =item I<0-9>
 
 Nth monitor.
+
+=item I<n>B<NAME>
+
+Named monitor.
+Eg. I<%{SnHDMI-0} This text will show up on the HDMI-0 output>
 
 =back
 


### PR DESCRIPTION
Added -o <NAME> option, that can be used multiple times on command line to add outputs. Excludes all other outputs and not given with -o option. Only works for randr, not xinerama, unless someone can point me to accessing output names with xinerama extension (I haven't found any). Could be made to default to whole screen if named screens not found, though this seems convoluted to me since it covers up the failure to find any name screens and makes the error less obvious to the user.

Tested on my multimonitor rig here using multiple configs, with and without using the -o option, changing order, misspelling on purpose, etc, etc. Could probably use more testing, but seems to work consistantly AFAICT.
