### PR TITLE
Keep percent signs if not followed by {} block.

### DIFF
--- a/lemonbar.c
+++ b/lemonbar.c
@@ -485,7 +485,8 @@ parse (char *text)
         if (*p == '\0' || *p == '\n')
             return;
 
-        if (*p == '%' && p++ && *p == '{' && (block_end = strchr(p++, '}'))) {
+        if (*p == '%' && *(p+1) == '{' && (block_end = strchr(p++, '}'))) {
+            p++;
             while (p < block_end) {
                 while (isspace(*p))
                     p++;

--- a/lemonbar.c
+++ b/lemonbar.c
@@ -485,7 +485,7 @@ parse (char *text)
         if (*p == '\0' || *p == '\n')
             return;
 
-        if (*p == '%' && *(p+1) == '{' && (block_end = strchr(p++, '}'))) {
+        if (p[0] == '%' && p[1] == '{' && (block_end = strchr(p++, '}'))) {
             p++;
             while (p < block_end) {
                 while (isspace(*p))


### PR DESCRIPTION
The before code would skip a percent sign even if it was not followed by a {}
block. The after code checks the same condition but only advances p if a {} block
is found and otherwise passes it through as text.