### PR TITLE
Fix monitor sorting with mix of portrait and landscape layout.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-config.h
-bar
+lemonbar
 *.o
 *.swp
 *~

--- a/lemonbar.c
+++ b/lemonbar.c
@@ -541,7 +541,7 @@ parse (char *text)
                               break;
 
                     case 'T':
-                              if (*p == '-') { //Reset to automatic font selection 
+                              if (*p == '-') { //Reset to automatic font selection
                                   font_index = -1;
                                   p++;
                                   break;
@@ -784,10 +784,15 @@ rect_sort_cb (const void *p1, const void *p2)
     const xcb_rectangle_t *r1 = (xcb_rectangle_t *)p1;
     const xcb_rectangle_t *r2 = (xcb_rectangle_t *)p2;
 
-    if (r1->x < r2->x || r1->y < r2->y)
+    if (r1->x < r2->x || r1->y + r1->height <= r2->y)
+    {
         return -1;
-    if (r1->x > r2->x || r1->y > r2->y)
-        return  1;
+    }
+
+    if (r1->x > r2->x || r1->y + r1->height > r2->y)
+    {
+        return 1;
+    }
 
     return 0;
 }


### PR DESCRIPTION
This PR changes monitor sorting to keep sorting by x and y coordinates, but also takes into account a height comparison that I believe fixes sorting in currently unexpected monitor situations. This is done in a way that keeps current monitor sorting the same on setups with the y offset aligned across the top, so impact should be minimal. 

This includes https://github.com/LemonBoy/bar/pull/118

Notes for how I got here and screenshots along the way are attached to https://github.com/LemonBoy/bar/issues/147 (It's unorganized as I commented as I went along) - this was tested in 3 different monitor layouts with different geometry spawns, as seen there. 
