### PR TITLE
Fix the missing scrolling wheel support.

### DIFF
--- a/lemonbar.c
+++ b/lemonbar.c
@@ -40,7 +40,7 @@ typedef struct area_t {
     unsigned int end:16;
     bool active:1;
     int align:3;
-    int button:3;
+    int button;
     xcb_window_t window;
     char *cmd;
 } area_t;

--- a/lemonbar.c
+++ b/lemonbar.c
@@ -40,7 +40,7 @@ typedef struct area_t {
     unsigned int end:16;
     bool active:1;
     int align:3;
-    int button;
+    unsigned int button:3;
     xcb_window_t window;
     char *cmd;
 } area_t;


### PR DESCRIPTION
Fix LemonBoy/bar#154 and krypt-n/bar#18

Problem was that an int:3 has a range of -4 to 3, buttons 4 and 5 did not
fit into it.
Why do we need to try to save memory by using bitfields here?