### PR TITLE
Implement [Issue #161 - Feature request]

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -6,7 +6,7 @@ lemonbar - Featherweight lemon-scented bar
 
 =head1 SYNOPSIS
 
-I<lemonbar> [-h | -g I<width>B<x>I<height>B<+>I<x>B<+>I<y> | -b | -d | -f I<font> | -p | -n I<name> | -u I<pixel> | -B I<color> | -F I<color>]
+I<lemonbar> [-h | -g I<width>B<x>I<height>B<+>I<x>B<+>I<y> | -b | -d | -f I<font> | -p | -n I<name> | -u I<pixel> | -B I<color> | -F I<color> | -U I<color>]
 
 =head1 DESCRIPTION
 
@@ -60,6 +60,10 @@ Set the background color of the bar. I<color> must be specified in the hex forma
 =item B<-F> I<color>
 
 Set the foreground color of the bar. Accepts the same color formats as B<-B>.
+
+=item B<-U> I<color>
+
+Set the underline color of the bar. Accepts the same color formats as B<-B>.
 
 =back
 

--- a/lemonbar.c
+++ b/lemonbar.c
@@ -95,7 +95,7 @@ static bool topbar = true;
 static int bw = -1, bh = -1, bx = 0, by = 0;
 static int bu = 1; // Underline height
 static rgba_t fgc, bgc, ugc;
-static rgba_t dfgc, dbgc;
+static rgba_t dfgc, dbgc, dugc;
 static area_stack_t area_stack;
 
 void
@@ -520,7 +520,7 @@ parse (char *text)
 
                     case 'B': bgc = parse_color(p, &p, dbgc); update_gc(); break;
                     case 'F': fgc = parse_color(p, &p, dfgc); update_gc(); break;
-                    case 'U': ugc = parse_color(p, &p, dbgc); update_gc(); break;
+                    case 'U': ugc = parse_color(p, &p, dugc); update_gc(); break;
 
                     case 'S':
                               if (*p == '+' && cur_mon->next)
@@ -1238,8 +1238,7 @@ main (int argc, char **argv)
     // B/W combo
     dbgc = bgc = (rgba_t)0x00000000U;
     dfgc = fgc = (rgba_t)0xffffffffU;
-
-    ugc = fgc;
+    dugc = ugc = fgc;
 
     // A safe default
     areas = 10;
@@ -1248,7 +1247,7 @@ main (int argc, char **argv)
     // Connect to the Xserver and initialize scr
     xconn();
 
-    while ((ch = getopt(argc, argv, "hg:bdf:a:pu:B:F:n:")) != -1) {
+    while ((ch = getopt(argc, argv, "hg:bdf:a:pu:B:F:U:n:")) != -1) {
         switch (ch) {
             case 'h':
                 printf ("lemonbar version %s\n", VERSION);
@@ -1274,6 +1273,7 @@ main (int argc, char **argv)
             case 'u': bu = strtoul(optarg, NULL, 10); break;
             case 'B': dbgc = bgc = parse_color(optarg, NULL, (rgba_t)0x00000000U); break;
             case 'F': dfgc = fgc = parse_color(optarg, NULL, (rgba_t)0xffffffffU); break;
+            case 'U': dugc = ugc = parse_color(optarg, NULL, fgc); break;
             case 'a': areas = strtoul(optarg, NULL, 10); break;
         }
     }


### PR DESCRIPTION
Feature #161: add a parametere to set the default underline color.
Usage: lemonbar -Ucolor

By the way this also fix a strange behavior where '%{+u}correct%{U-}strange'
made the second underline of the same color as the background instead of the foreground.
This was because underline color is set to fg color at initialisation but %{U-} was setting the underline color to the default bg color. So with a default underline color this behavior disapear.