### PR TITLE
Document literal percent sign under formatting

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -69,7 +69,7 @@ Set the underline color of the bar. Accepts the same color formats as B<-B>.
 
 =head1 FORMATTING
 
-lemonbar provides a screenrc-inspired formatting syntax to allow full customization at runtime. Every formatting block is opened with B<%{> and closed by B<}> and accepts the following commands, the parser tries it's best to handle malformed input.
+lemonbar provides a screenrc-inspired formatting syntax to allow full customization at runtime. Every formatting block is opened with C<%{> and closed by C<}> and accepts the following commands, the parser tries it's best to handle malformed input. Use C<%%> to get a literal percent sign (C<%>).
 
 =over
 


### PR DESCRIPTION
(Feel free to reject this if you don't want this or think it's unnecessary.)