### PR TITLE
Fix {top,bottom}_end_x strut value

### DIFF
--- a/lemonbar.c
+++ b/lemonbar.c
@@ -752,11 +752,11 @@ set_ewmh_atoms (void)
         if (topbar) {
             strut[2] = bh;
             strut[8] = mon->x;
-            strut[9] = mon->x + mon->width;
+            strut[9] = mon->x + mon->width - 1;
         } else {
             strut[3]  = bh;
             strut[10] = mon->x;
-            strut[11] = mon->x + mon->width;
+            strut[11] = mon->x + mon->width - 1;
         }
 
         xcb_change_property(c, XCB_PROP_MODE_REPLACE, mon->window, atom_list[NET_WM_WINDOW_TYPE], XCB_ATOM_ATOM, 32, 1, &atom_list[NET_WM_WINDOW_TYPE_DOCK]);


### PR DESCRIPTION
The maximum x coordinate of a pixel inside the rectangle (x, y, w, h) is x+w-1.

The specs (https://specifications.freedesktop.org/wm-spec/wm-spec-1.3.html#idm140130317564416) provides an example that corroborates the fact that the range is inclusive: bottom_end_x is 2303. This value can be interpreted as 1280+1024-1.