### PR TITLE
Added -o option for writing a startup message on stdout

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -65,6 +65,10 @@ Set the foreground color of the bar. Accepts the same color formats as B<-B>.
 
 Set the underline color of the bar. Accepts the same color formats as B<-B>.
 
+=item B<-o>
+
+Print a message ("started\n") to sdtout when the bar has been initialized.
+
 =back
 
 =head1 FORMATTING

--- a/lemonbar.c
+++ b/lemonbar.c
@@ -1264,6 +1264,7 @@ main (int argc, char **argv)
     xcb_button_press_event_t *press_ev;
     char input[4096] = {0, };
     bool permanent = false;
+    bool startup_notification = false;
     int geom_v[4] = { -1, -1, 0, 0 };
     int ch, areas;
     char *wm_name;
@@ -1285,7 +1286,7 @@ main (int argc, char **argv)
     // Connect to the Xserver and initialize scr
     xconn();
 
-    while ((ch = getopt(argc, argv, "hg:bdf:a:pu:B:F:U:n:")) != -1) {
+    while ((ch = getopt(argc, argv, "hg:bdf:a:pu:B:F:U:n:o")) != -1) {
         switch (ch) {
             case 'h':
                 printf ("lemonbar version %s\n", VERSION);
@@ -1300,7 +1301,8 @@ main (int argc, char **argv)
                         "\t-n Set the WM_NAME atom to the specified value for this bar\n"
                         "\t-u Set the underline/overline height in pixels\n"
                         "\t-B Set background color in #AARRGGBB\n"
-                        "\t-F Set foreground color in #AARRGGBB\n", argv[0]);
+                        "\t-F Set foreground color in #AARRGGBB\n"
+                        "\t-o Write a message to stdout when started\n", argv[0]);
                 exit (EXIT_SUCCESS);
             case 'g': (void)parse_geometry_string(optarg, geom_v); break;
             case 'p': permanent = true; break;
@@ -1313,6 +1315,7 @@ main (int argc, char **argv)
             case 'F': dfgc = fgc = parse_color(optarg, NULL, (rgba_t)0xffffffffU); break;
             case 'U': dugc = ugc = parse_color(optarg, NULL, fgc); break;
             case 'a': areas = strtoul(optarg, NULL, 10); break;
+            case 'o': startup_notification = true; break;
         }
     }
 
@@ -1339,6 +1342,11 @@ main (int argc, char **argv)
 
     // Do the heavy lifting
     init(wm_name);
+    
+    if(startup_notification){
+        (void)write(STDOUT_FILENO, "started\n", 8);
+    }
+    
     // The string is strdup'd when the command line arguments are parsed
     free(wm_name);
     // Get the fd to Xserver


### PR DESCRIPTION
Not sure if you want this, or if this is a good implementation of what I want to accomplish;

Basically what I want to do is to run some code AFTER the bar has been initialized, more spesifically after the WM_NAME has been set and can be queried by other tools like baskerville/xdo.
For instance the example code in bspwm forces the bar to go behind fullscreen windows by running a loop until you can get the window ID from the WM_NAME: https://github.com/baskerville/bspwm/blob/master/examples/panel/panel

I use nodejs to do basically the same (I can't do bash scripts for the life of me...), but I don't like having to do the while loop and check multiple times to see if the window is up or not.
With this change I can have the parent process wait for lemonbar to print out "started\n" and then run the xdo code. It's working for me, but like I said, I'm not sure if this is the best way to implement this.