### PR TITLE
Skip mirrored outputs

### DIFF
--- a/lemonbar.c
+++ b/lemonbar.c
@@ -1054,7 +1054,7 @@ get_randr_monitors (void)
         for (j = 0; j < num; j++) {
             // Does I contain J ?
 
-            if (i != j && mons[j].width && !mons[j].name) {
+            if (i != j && mons[j].width) {
                 if (mons[j].x >= mons[i].x && mons[j].x + mons[j].width <= mons[i].x + mons[i].width &&
                     mons[j].y >= mons[i].y && mons[j].y + mons[j].height <= mons[i].y + mons[i].height) {
                     mons[j].width = 0;


### PR DESCRIPTION
I think that https://github.com/LemonBoy/bar/issues/241 reports an issue that I'm also seeing: if I start `lemonbar` after I have a second monitor connected as a mirror, I get two bars, but they are both docked to the bottom of the same screen, and the blank one covers the real one.

I've tested this commit and it seems to fix this behavior.

(I'm a big fan of `lemonbar`, thanks for writing it!)