### PR TITLE
make bar always below other windows

### DIFF
--- a/lemonbar.c
+++ b/lemonbar.c
@@ -1318,7 +1318,7 @@ init (char *wm_name)
 
         // Make sure that the window really gets in the place it's supposed to be
         // Some WM such as Openbox need this
-        xcb_configure_window(c, mon->window, XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y, (const uint32_t []){ mon->x, mon->y });
+        xcb_configure_window(c, mon->window, XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y | XCB_CONFIG_WINDOW_STACK_MODE, (const uint32_t []){ mon->x, mon->y, XCB_STACK_MODE_BELOW });
 
         // Set the WM_NAME atom to the user specified value
         if (wm_name)


### PR DESCRIPTION
I'm using bspwm, and when lemonbar is running and I open a window in fullscreen mode (for example using `bspc node -t fullscreen`), the bar remains above this fullscreen window

this issue was discussed in #204 